### PR TITLE
Ensure packages with `git://` resolved urls do not get stripped

### DIFF
--- a/pliers-clean-shrinkwrap.js
+++ b/pliers-clean-shrinkwrap.js
@@ -14,7 +14,7 @@ module.exports = function (pliers) {
       , shrinkwrap = require(shrinkwrapPath)
 
     function replacer(key, val) {
-      var fromGitUrl = this.from && this.from.match(/.git|git:\/\//)
+      var fromGitUrl = this.from && typeof this.from === 'string' && this.from.match(/.git|git:\/\//)
         , resolvedGitUrl = this.resolved && this.resolved.match(/.git|git:\/\//)
 
       if (key === 'resolved' && this.version && !fromGitUrl && !resolvedGitUrl) {

--- a/pliers-clean-shrinkwrap.js
+++ b/pliers-clean-shrinkwrap.js
@@ -14,7 +14,10 @@ module.exports = function (pliers) {
       , shrinkwrap = require(shrinkwrapPath)
 
     function replacer(key, val) {
-      if (key === 'resolved' && this.from && this.version && (!this.from.match(/.git|git:\/\//))) {
+      var fromGitUrl = this.from && this.from.match(/.git|git:\/\//)
+        , resolvedGitUrl = this.resolved && this.resolved.match(/.git|git:\/\//)
+
+      if (key === 'resolved' && this.version && !fromGitUrl && !resolvedGitUrl) {
         pliers.logger.debug('Removing', val)
         return undefined
       } else {

--- a/test/fixture.npm-shrinkwrap.json
+++ b/test/fixture.npm-shrinkwrap.json
@@ -24,6 +24,10 @@
       "resolved": "git://github.com/substack/esprima#0a7f8489a11b44b019ce168506f535f22d0be290",
       "dependencies": {}
     },
+    "from": {
+      "version": "0.1.3",
+      "from": "from@>=0.0.0 <1.0.0"
+    },
     "glob": {
       "version": "3.1.21",
       "from": "glob@~3.1",

--- a/test/fixture.npm-shrinkwrap.json
+++ b/test/fixture.npm-shrinkwrap.json
@@ -98,6 +98,12 @@
           "resolved": "http://npm.clockte.ch/colors/-/colors-0.6.2.tgz"
         }
       }
+    },
+    "github-shorthand-url": {
+      "version": "1",
+      "from": "substack/esprima#is-keyword",
+      "resolved": "git://github.com/substack/esprima#0a7f8489a11b44b019ce168506f535f22d0be290",
+      "dependencies": {}
     }
   }
 }

--- a/test/npm-shrinkwrap.json
+++ b/test/npm-shrinkwrap.json
@@ -22,6 +22,10 @@
       "resolved": "git://github.com/substack/esprima#0a7f8489a11b44b019ce168506f535f22d0be290",
       "dependencies": {}
     },
+    "from": {
+      "version": "0.1.3",
+      "from": "from@>=0.0.0 <1.0.0"
+    },
     "glob": {
       "version": "3.1.21",
       "from": "glob@~3.1",

--- a/test/npm-shrinkwrap.json
+++ b/test/npm-shrinkwrap.json
@@ -83,6 +83,12 @@
           "from": "colors@~0.6.0-1"
         }
       }
+    },
+    "github-shorthand-url": {
+      "version": "1",
+      "from": "substack/esprima#is-keyword",
+      "resolved": "git://github.com/substack/esprima#0a7f8489a11b44b019ce168506f535f22d0be290",
+      "dependencies": {}
     }
   }
 }

--- a/test/pliers-clean-shrinkwrap.test.js
+++ b/test/pliers-clean-shrinkwrap.test.js
@@ -8,7 +8,7 @@ describe('pliers-clean-shrinkwrap', function () {
   beforeEach(function (done) {
     fs.unlinkSync(shrinkWrapPath)
     fs.createReadStream(__dirname + '/fixture.npm-shrinkwrap.json')
-    .pipe(fs.createWriteStream(__dirname + '/npm-shrinkwrap.json'))
+    .pipe(fs.createWriteStream(shrinkWrapPath))
     .on('finish', done)
   })
 
@@ -27,6 +27,7 @@ describe('pliers-clean-shrinkwrap', function () {
       var shrinkWrap = JSON.parse(fs.readFileSync(shrinkWrapPath))
       shrinkWrap.dependencies['git-package'].should.have.property('resolved')
       shrinkWrap.dependencies['git-protocol-package'].should.have.property('resolved')
+      shrinkWrap.dependencies['github-shorthand-url'].should.have.property('resolved')
       done()
     })
   })

--- a/test/pliers-clean-shrinkwrap.test.js
+++ b/test/pliers-clean-shrinkwrap.test.js
@@ -1,6 +1,7 @@
 var createPliers = require('pliers').bind(null, { cwd: __dirname, logLevel: 'error' })
   , cleanShrinkwrap = require('..')
   , fs = require('fs')
+  , assert = require('assert')
   , shrinkWrapPath = __dirname + '/npm-shrinkwrap.json'
 
 describe('pliers-clean-shrinkwrap', function () {
@@ -30,5 +31,12 @@ describe('pliers-clean-shrinkwrap', function () {
       shrinkWrap.dependencies['github-shorthand-url'].should.have.property('resolved')
       done()
     })
+  })
+
+  it('should not throw if the package name is `from`', function () {
+    var pliers = createPliers()
+    assert.doesNotThrow(function () {
+      cleanShrinkwrap(pliers)(function() {})
+    }, /Object #<Object> has no method 'match'/)
   })
 })


### PR DESCRIPTION
Shrink-wraps with the following:

`"from": "substack/esprima#is-keyword"`

get their resolved urls stripped out which results in errors on CI due
to unresolvable packages
